### PR TITLE
Fix reading z coordinate from a position

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -175,14 +175,14 @@ pub fn read_position<R: Read>(reader: &mut R) -> Result<(i32, i32, i32)> {
     let val = read_u64(reader)?;
     let mut x = (val >> 38) as i32;
     let mut y = ((val >> 26) & 0xfff) as i32;
-    let mut z = (val & 0x3ffffff) as i32;
+    let mut z = (val << 38 >> 38) as i32;
     if x >= 1 << 25 {
         x -= 1 << 26;
     }
     if y >= 1 << 11 {
         y -= 1 << 12;
     }
-    if z >= 2 << 25 {
+    if z >= 1 << 25 {
         z -= 1 << 26;
     }
     Ok((x, y, z))

--- a/src/tests/datatypes.rs
+++ b/src/tests/datatypes.rs
@@ -79,4 +79,8 @@ fn position() {
                     &[0xff, 0xe0, 0x62, 0xbe, 0xe0, 0x00, 0x72, 0x63],
                     read_position,
                     write_position);
+    read_and_write!((-109, 64, -120),
+                    &[0xff, 0xff, 0xe4, 0xc1, 0x03, 0xff, 0xff, 0x88],
+                    read_position,
+                    write_position);
 }


### PR DESCRIPTION
A simple typo was causing negative Z coordinates to not be read
correctly (though they were still written back correctly).